### PR TITLE
Increase max DB packet size

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: "3"
 services:
   db:
     image: mariadb
+    command: --max_allowed_packet=268435456
     environment:
       - MYSQL_ROOT_PASSWORD=supersecret
       - MYSQL_DATABASE=unimus


### PR DESCRIPTION
Increased max DB packet size from default 16MB. Default value would cause backups larger than 16MB to fail to write to DB.