### PR TITLE
Added binary verification during image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get install -y openjdk-11-jre-headless
 #
 # Unimus 
 RUN curl -L -o /opt/unimus.jar $DOWNLOAD_URL
+RUN jarsigner -verify /opt/unimus.jar | grep 'jar verified'
 #
 # Start script
 COPY files/start.sh /opt/start.sh


### PR DESCRIPTION
Starting with 2.1 we have implemented code-signing in all binaries. Perhaps it would be worth (for security reasons) to validate binary signature as a part of image build?