### PR TITLE
Unimus has no support for MariaDB 11 yet, pin image to MariaDB 10

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   db:
-    image: mariadb
+    image: mariadb:10
     command: --max_allowed_packet=268M
     environment:
       - MYSQL_ROOT_PASSWORD=supersecret


### PR DESCRIPTION
Unimus doesn't support MariaDB 11, yet.
This simple fix pins mariadb to the latest version 10 image in docker-compose.